### PR TITLE
feat(api-gateway): add products endpoint

### DIFF
--- a/services/api-gateway/src/app/app.controller.spec.ts
+++ b/services/api-gateway/src/app/app.controller.spec.ts
@@ -18,14 +18,4 @@ describe('AppController', () => {
       expect(appController.getData()).toEqual({ message: 'Hello API' });
     });
   });
-
-  describe('ready', () => {
-    it('should include uptime', () => {
-      const appController = app.get<AppController>(AppController);
-      const result = appController.ready();
-      expect(result.status).toBe('ready');
-      expect(result.service).toBe('api-gateway');
-      expect(typeof result.uptime).toBe('number');
-    });
-  });
 });

--- a/services/api-gateway/src/app/app.controller.ts
+++ b/services/api-gateway/src/app/app.controller.ts
@@ -9,24 +9,4 @@ export class AppController {
   getData() {
     return this.appService.getData();
   }
-
-  @Get('health')
-  health() {
-    return {
-      status: 'ok',
-      service: 'api-gateway',
-      timestamp: new Date().toISOString(),
-      uptime: process.uptime()
-    };
-  }
-
-  @Get('ready')
-  ready() {
-    return {
-      status: 'ready',
-      service: 'api-gateway',
-      timestamp: new Date().toISOString(),
-      uptime: process.uptime()
-    };
-  }
 }

--- a/services/api-gateway/src/app/app.module.ts
+++ b/services/api-gateway/src/app/app.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthModule } from '@my-microservices/shared-utils';
+import { ProductsController } from './products.controller';
+import { ProductsService } from './products.service';
 
 @Module({
   imports: [HealthModule.register('api-gateway')],
-  controllers: [AppController],
-  providers: [AppService],
+  controllers: [AppController, ProductsController],
+  providers: [AppService, ProductsService],
 })
 export class AppModule {}

--- a/services/api-gateway/src/app/products.controller.spec.ts
+++ b/services/api-gateway/src/app/products.controller.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsController } from './products.controller';
+import { ProductsService } from './products.service';
+
+describe('ProductsController', () => {
+  let controller: ProductsController;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProductsController],
+      providers: [ProductsService],
+    }).compile();
+
+    controller = module.get<ProductsController>(ProductsController);
+  });
+
+  it('should return a list of products', () => {
+    const products = controller.findAll();
+    expect(products.length).toBeGreaterThan(0);
+    expect(products[0]).toHaveProperty('id');
+    expect(products[0]).toHaveProperty('name');
+  });
+});

--- a/services/api-gateway/src/app/products.controller.ts
+++ b/services/api-gateway/src/app/products.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { Product } from '@my-microservices/shared-types';
+
+@Controller('products')
+export class ProductsController {
+  constructor(private readonly productsService: ProductsService) {}
+
+  @Get()
+  findAll(): Product[] {
+    return this.productsService.findAll();
+  }
+}

--- a/services/api-gateway/src/app/products.service.ts
+++ b/services/api-gateway/src/app/products.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { Product } from '@my-microservices/shared-types';
+
+@Injectable()
+export class ProductsService {
+  private readonly products: Product[] = [
+    { id: '1', name: 'Organic Rice', category: 'grain', price: 500, location: 'Bangkok' },
+    { id: '2', name: 'Dried Mango', category: 'fruit', price: 120, location: 'Chiang Mai' }
+  ];
+
+  findAll(): Product[] {
+    return this.products;
+  }
+}

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/shared-types';
+export * from './lib/product';

--- a/shared-types/src/lib/product.ts
+++ b/shared-types/src/lib/product.ts
@@ -1,0 +1,7 @@
+export interface Product {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  location: string;
+}


### PR DESCRIPTION
## Summary
- add reusable `Product` type for microservices
- expose `/products` endpoint with sample data in API gateway
- remove redundant health routes in API gateway controller

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c15bdb794832caea67235fe5df497