### PR TITLE
feat: fetch users from api service

### DIFF
--- a/services/api-users/src/app/app.controller.spec.ts
+++ b/services/api-users/src/app/app.controller.spec.ts
@@ -18,4 +18,14 @@ describe('AppController', () => {
       expect(appController.getData()).toEqual({ message: 'Hello API' });
     });
   });
+
+  describe('getUsers', () => {
+    it('should return an array of users', () => {
+      const appController = app.get<AppController>(AppController);
+      expect(appController.getUsers()).toEqual([
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ]);
+    });
+  });
 });

--- a/services/api-users/src/app/app.controller.ts
+++ b/services/api-users/src/app/app.controller.ts
@@ -9,4 +9,9 @@ export class AppController {
   getData() {
     return this.appService.getData();
   }
+
+  @Get('users')
+  getUsers() {
+    return this.appService.getUsers();
+  }
 }

--- a/services/api-users/src/app/app.service.spec.ts
+++ b/services/api-users/src/app/app.service.spec.ts
@@ -17,4 +17,13 @@ describe('AppService', () => {
       expect(service.getData()).toEqual({ message: 'Hello API' });
     });
   });
+
+  describe('getUsers', () => {
+    it('should return an array of users', () => {
+      expect(service.getUsers()).toEqual([
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+      ]);
+    });
+  });
 });

--- a/services/api-users/src/app/app.service.ts
+++ b/services/api-users/src/app/app.service.ts
@@ -5,4 +5,11 @@ export class AppService {
   getData(): { message: string } {
     return { message: 'Hello API' };
   }
+
+  getUsers(): { id: number; name: string }[] {
+    return [
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ];
+  }
 }

--- a/services/web-portal/src/app/page.tsx
+++ b/services/web-portal/src/app/page.tsx
@@ -1,14 +1,24 @@
 import styles from './page.module.scss';
 
-export default function Index() {
-  /*
-   * Replace the elements below with your own.
-   *
-   * Note: The corresponding styles are in the ./index.scss file.
-   */
+type User = { id: number; name: string };
+
+async function fetchUsers(): Promise<User[]> {
+  const baseUrl = process.env.API_USERS_URL || 'http://localhost:3001';
+  const res = await fetch(`${baseUrl}/api/users`, { cache: 'no-store' });
+  return res.json();
+}
+
+export default async function Index() {
+  const users = await fetchUsers();
+
   return (
     <div className={styles.page}>
-      <h1>Hello World</h1>
+      <h1>Users</h1>
+      <ul>
+        {users.map((user) => (
+          <li key={user.id}>{user.name}</li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expose `/users` endpoint in api-users with mock user data
- display user list in web-portal by fetching api-users service
- add tests covering new endpoint

## Testing
- `npx nx test api-users`

------
https://chatgpt.com/codex/tasks/task_e_689c30c72304832ca467c93f40c26345