### PR TITLE
Handle user fetch errors in web portal

### DIFF
--- a/services/web-portal/src/app/page.tsx
+++ b/services/web-portal/src/app/page.tsx
@@ -3,9 +3,22 @@ import styles from './page.module.scss';
 type User = { id: number; name: string };
 
 async function fetchUsers(): Promise<User[]> {
-  const baseUrl = process.env.API_USERS_URL || 'http://localhost:3001';
-  const res = await fetch(`${baseUrl}/api/users`, { cache: 'no-store' });
-  return res.json();
+  const baseUrl =
+    process.env.API_BASE_URL ||
+    process.env.API_USERS_URL ||
+    'http://localhost:3000';
+
+  try {
+    const res = await fetch(`${baseUrl}/api/users`, { cache: 'no-store' });
+    if (!res.ok) {
+      console.error('Failed to fetch users', res.statusText);
+      return [];
+    }
+    return res.json();
+  } catch (err) {
+    console.error('Failed to fetch users', err);
+    return [];
+  }
 }
 
 export default async function Index() {


### PR DESCRIPTION
## Summary
- add fallback API base URL selection and catch errors when fetching users

## Testing
- `npx nx test web-portal --skip-nx-cache --verbose`
- `npx nx lint web-portal --skip-nx-cache`


------
https://chatgpt.com/codex/tasks/task_e_689c32fc8634832c8ee2bd65986315d0