### PR TITLE
feat(api-users): add CRUD endpoints

### DIFF
--- a/services/api-users/src/app/app.controller.spec.ts
+++ b/services/api-users/src/app/app.controller.spec.ts
@@ -4,28 +4,33 @@ import { AppService } from './app.service';
 
 describe('AppController', () => {
   let app: TestingModule;
+  let controller: AppController;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     app = await Test.createTestingModule({
       controllers: [AppController],
       providers: [AppService],
     }).compile();
+    controller = app.get<AppController>(AppController);
   });
 
   describe('getData', () => {
     it('should return "Hello API"', () => {
-      const appController = app.get<AppController>(AppController);
-      expect(appController.getData()).toEqual({ message: 'Hello API' });
+      expect(controller.getData()).toEqual({ message: 'Hello API' });
     });
   });
 
-  describe('getUsers', () => {
-    it('should return an array of users', () => {
-      const appController = app.get<AppController>(AppController);
-      expect(appController.getUsers()).toEqual([
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ]);
+  describe('users CRUD', () => {
+    it('should create, retrieve, update and delete a user', () => {
+      expect(controller.getUsers()).toHaveLength(2);
+      const created = controller.createUser({ name: 'Charlie' });
+      expect(created).toEqual({ id: 3, name: 'Charlie' });
+      expect(controller.getUser('3')).toEqual({ id: 3, name: 'Charlie' });
+      const updated = controller.updateUser('3', { name: 'Charles' });
+      expect(updated).toEqual({ id: 3, name: 'Charles' });
+      const removed = controller.deleteUser('3');
+      expect(removed).toEqual({ id: 3, name: 'Charles' });
+      expect(controller.getUser('3')).toBeUndefined();
     });
   });
 });

--- a/services/api-users/src/app/app.controller.ts
+++ b/services/api-users/src/app/app.controller.ts
@@ -1,5 +1,15 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { AppService } from './app.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Controller()
 export class AppController {
@@ -10,8 +20,31 @@ export class AppController {
     return this.appService.getData();
   }
 
+  @Post('users')
+  createUser(@Body() dto: CreateUserDto) {
+    return this.appService.createUser(dto.name);
+  }
+
   @Get('users')
   getUsers() {
     return this.appService.getUsers();
+  }
+
+  @Get('users/:id')
+  getUser(@Param('id') id: string) {
+    return this.appService.getUser(+id);
+  }
+
+  @Put('users/:id')
+  updateUser(
+    @Param('id') id: string,
+    @Body() dto: UpdateUserDto
+  ) {
+    return this.appService.updateUser(+id, dto.name);
+  }
+
+  @Delete('users/:id')
+  deleteUser(@Param('id') id: string) {
+    return this.appService.deleteUser(+id);
   }
 }

--- a/services/api-users/src/app/app.service.spec.ts
+++ b/services/api-users/src/app/app.service.spec.ts
@@ -4,7 +4,7 @@ import { AppService } from './app.service';
 describe('AppService', () => {
   let service: AppService;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const app = await Test.createTestingModule({
       providers: [AppService],
     }).compile();
@@ -18,12 +18,17 @@ describe('AppService', () => {
     });
   });
 
-  describe('getUsers', () => {
-    it('should return an array of users', () => {
-      expect(service.getUsers()).toEqual([
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ]);
+  describe('users CRUD', () => {
+    it('should create, retrieve, update and delete a user', () => {
+      expect(service.getUsers()).toHaveLength(2);
+      const created = service.createUser('Charlie');
+      expect(created).toEqual({ id: 3, name: 'Charlie' });
+      expect(service.getUser(3)).toEqual({ id: 3, name: 'Charlie' });
+      const updated = service.updateUser(3, 'Charles');
+      expect(updated).toEqual({ id: 3, name: 'Charles' });
+      const removed = service.deleteUser(3);
+      expect(removed).toEqual({ id: 3, name: 'Charles' });
+      expect(service.getUser(3)).toBeUndefined();
     });
   });
 });

--- a/services/api-users/src/app/app.service.ts
+++ b/services/api-users/src/app/app.service.ts
@@ -1,15 +1,50 @@
 import { Injectable } from '@nestjs/common';
 
+interface User {
+  id: number;
+  name: string;
+}
+
 @Injectable()
 export class AppService {
+  private users: User[] = [
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' },
+  ];
+  private nextId = 3;
+
   getData(): { message: string } {
     return { message: 'Hello API' };
   }
 
-  getUsers(): { id: number; name: string }[] {
-    return [
-      { id: 1, name: 'Alice' },
-      { id: 2, name: 'Bob' },
-    ];
+  getUsers(): User[] {
+    return this.users;
+  }
+
+  getUser(id: number): User | undefined {
+    return this.users.find((u) => u.id === id);
+  }
+
+  createUser(name: string): User {
+    const user: User = { id: this.nextId++, name };
+    this.users.push(user);
+    return user;
+  }
+
+  updateUser(id: number, name?: string): User | undefined {
+    const user = this.getUser(id);
+    if (user && name !== undefined) {
+      user.name = name;
+    }
+    return user;
+  }
+
+  deleteUser(id: number): User | undefined {
+    const index = this.users.findIndex((u) => u.id === id);
+    if (index >= 0) {
+      const [removed] = this.users.splice(index, 1);
+      return removed;
+    }
+    return undefined;
   }
 }

--- a/services/api-users/src/app/dto/create-user.dto.ts
+++ b/services/api-users/src/app/dto/create-user.dto.ts
@@ -1,0 +1,4 @@
+export class CreateUserDto {
+  name!: string;
+}
+

--- a/services/api-users/src/app/dto/update-user.dto.ts
+++ b/services/api-users/src/app/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+export class UpdateUserDto {
+  name?: string;
+}
+


### PR DESCRIPTION
## Summary
- add in-memory user store with create, read, update, delete methods
- expose REST endpoints for user management
- cover new behavior with unit tests

## Testing
- `npx nx test api-users`
- `npx nx lint api-users`


------
https://chatgpt.com/codex/tasks/task_e_689c3778dde4832c92b98bc05ef4ac29