### PR TITLE
feat(web-portal): add user CRUD interface

### DIFF
--- a/services/web-portal/src/app/page.module.scss
+++ b/services/web-portal/src/app/page.module.scss
@@ -1,2 +1,37 @@
 .page {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.listItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+.actions button {
+  margin-left: 0.5rem;
 }

--- a/services/web-portal/src/app/page.tsx
+++ b/services/web-portal/src/app/page.tsx
@@ -1,35 +1,139 @@
+"use client";
+
+import { useEffect, useState } from 'react';
 import styles from './page.module.scss';
 
 type User = { id: number; name: string };
 
-async function fetchUsers(): Promise<User[]> {
-  const baseUrl =
-    process.env.API_BASE_URL ||
-    process.env.API_USERS_URL ||
-    'http://localhost:3000';
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  process.env.NEXT_PUBLIC_API_USERS_URL ||
+  'http://localhost:3000';
 
-  try {
-    const res = await fetch(`${baseUrl}/api/users`, { cache: 'no-store' });
-    if (!res.ok) {
-      console.error('Failed to fetch users', res.statusText);
-      return [];
+export default function Index() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [newName, setNewName] = useState('');
+  const [editId, setEditId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+
+  const fetchUsers = async () => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/users`);
+      if (res.ok) {
+        setUsers(await res.json());
+      } else {
+        console.error('Failed to fetch users', res.statusText);
+      }
+    } catch (err) {
+      console.error('Failed to fetch users', err);
     }
-    return res.json();
-  } catch (err) {
-    console.error('Failed to fetch users', err);
-    return [];
-  }
-}
+  };
 
-export default async function Index() {
-  const users = await fetchUsers();
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const addUser = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      if (res.ok) {
+        setNewName('');
+        fetchUsers();
+      } else {
+        console.error('Failed to create user', res.statusText);
+      }
+    } catch (err) {
+      console.error('Failed to create user', err);
+    }
+  };
+
+  const startEdit = (user: User) => {
+    setEditId(user.id);
+    setEditName(user.name);
+  };
+
+  const cancelEdit = () => {
+    setEditId(null);
+    setEditName('');
+  };
+
+  const saveEdit = async (id: number) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/users/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: editName }),
+      });
+      if (res.ok) {
+        cancelEdit();
+        fetchUsers();
+      } else {
+        console.error('Failed to update user', res.statusText);
+      }
+    } catch (err) {
+      console.error('Failed to update user', err);
+    }
+  };
+
+  const deleteUser = async (id: number) => {
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/users/${id}`, {
+        method: 'DELETE',
+      });
+      if (res.ok) {
+        fetchUsers();
+      } else {
+        console.error('Failed to delete user', res.statusText);
+      }
+    } catch (err) {
+      console.error('Failed to delete user', err);
+    }
+  };
 
   return (
     <div className={styles.page}>
-      <h1>Users</h1>
-      <ul>
+      <h1 className={styles.title}>Users</h1>
+      <form onSubmit={addUser} className={styles.form}>
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New user name"
+        />
+        <button type="submit">Add</button>
+      </form>
+      <ul className={styles.list}>
         {users.map((user) => (
-          <li key={user.id}>{user.name}</li>
+          <li key={user.id} className={styles.listItem}>
+            {editId === user.id ? (
+              <>
+                <input
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                />
+                <div className={styles.actions}>
+                  <button onClick={() => saveEdit(user.id)}>Save</button>
+                  <button type="button" onClick={cancelEdit}>
+                    Cancel
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <span>{user.name}</span>
+                <div className={styles.actions}>
+                  <button onClick={() => startEdit(user)}>Edit</button>
+                  <button onClick={() => deleteUser(user.id)}>Delete</button>
+                </div>
+              </>
+            )}
+          </li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- add client-side user management page using API
- style user list with basic form and actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3d4388b4832c8d47f322d1181f9c