### PR TITLE
feat: add products microservice

### DIFF
--- a/Dockerfile.api-products
+++ b/Dockerfile.api-products
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm ci
+RUN npm run nx build api-products
+
+FROM node:20-alpine
+WORKDIR /srv
+ENV NODE_ENV=production
+COPY --from=build /app/dist/api-products ./dist
+COPY --from=build /app/dist/api-products/package.json ./
+COPY --from=build /app/dist/api-products/package-lock.json ./
+RUN npm ci --omit=dev
+EXPOSE 3002
+CMD ["node", "dist/main.js"]

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,11 @@ install: ## Install dependencies
 	npm ci
 
 build: ## Build all applications
-	@echo "$(GREEN)Building applications...$(NC)"
-	npx nx build api-gateway
-	npx nx build api-users
-	npx nx build web-portal
+        @echo "$(GREEN)Building applications...$(NC)"
+        npx nx build api-gateway
+        npx nx build api-users
+        npx nx build api-products
+        npx nx build web-portal
 
 test: ## Run tests
 	@echo "$(GREEN)Running tests...$(NC)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - PORT=3000
     depends_on:
       - rabbitmq
+      - api-users
+      - api-products
     networks:
       - microservices-network
 
@@ -24,6 +26,20 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
+    depends_on:
+      - rabbitmq
+    networks:
+      - microservices-network
+
+  api-products:
+    build:
+      context: .
+      dockerfile: Dockerfile.api-products
+    ports:
+      - "3002:3002"
+    environment:
+      - NODE_ENV=production
+      - PORT=3002
     depends_on:
       - rabbitmq
     networks:

--- a/env.example
+++ b/env.example
@@ -14,9 +14,13 @@ JWT_EXPIRES_IN=24h
 # API Gateway Configuration
 API_GATEWAY_PORT=3000
 API_USERS_URL=http://localhost:3001
+API_PRODUCTS_URL=http://localhost:3002
 
 # Users Service Configuration
 API_USERS_PORT=3001
+
+# Products Service Configuration
+API_PRODUCTS_PORT=3002
 
 # Web Portal Configuration
 WEB_PORTAL_PORT=4200

--- a/k8s/api-products-deployment.yaml
+++ b/k8s/api-products-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-products
+  labels:
+    app: api-products
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api-products
+  template:
+    metadata:
+      labels:
+        app: api-products
+    spec:
+      containers:
+      - name: api-products
+        image: api-products:latest
+        ports:
+        - containerPort: 3002
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3002"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-products-service
+spec:
+  selector:
+    app: api-products
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3002
+  type: ClusterIP

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,7 @@ NC='\033[0m' # No Color
 REGISTRY=${REGISTRY:-"localhost:5000"}
 IMAGE_PREFIX=${IMAGE_PREFIX:-"my-microservices"}
 TAG=${TAG:-"latest"}
-SERVICES=("api-gateway" "api-users" "web-portal")
+SERVICES=("api-gateway" "api-users" "api-products" "web-portal")
 
 echo -e "${GREEN}🚀 Starting build process for My Microservices${NC}"
 

--- a/services/api-gateway/src/app/products.controller.spec.ts
+++ b/services/api-gateway/src/app/products.controller.spec.ts
@@ -4,20 +4,26 @@ import { ProductsService } from './products.service';
 
 describe('ProductsController', () => {
   let controller: ProductsController;
+  let service: ProductsService;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProductsController],
       providers: [ProductsService],
-    }).compile();
+    })
+      .overrideProvider(ProductsService)
+      .useValue({
+        getProducts: jest.fn().mockResolvedValue([]),
+      })
+      .compile();
 
     controller = module.get<ProductsController>(ProductsController);
+    service = module.get<ProductsService>(ProductsService);
   });
 
-  it('should return a list of products', () => {
-    const products = controller.findAll();
-    expect(products.length).toBeGreaterThan(0);
-    expect(products[0]).toHaveProperty('id');
-    expect(products[0]).toHaveProperty('name');
+  it('should return a list of products', async () => {
+    const products = await controller.findAll();
+    expect(products).toEqual([]);
+    expect(service.getProducts).toHaveBeenCalled();
   });
 });

--- a/services/api-gateway/src/app/products.controller.ts
+++ b/services/api-gateway/src/app/products.controller.ts
@@ -1,13 +1,88 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpException,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { ProductsService } from './products.service';
-import { Product } from '@my-microservices/shared-types';
 
 @Controller('products')
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 
+  @Post()
+  async createProduct(
+    @Body() dto: { name: string; category: string; price: number; location: string },
+  ) {
+    try {
+      return await this.productsService.createProduct(dto);
+    } catch (error) {
+      throw new HttpException(
+        'Failed to create product',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
   @Get()
-  findAll(): Product[] {
-    return this.productsService.findAll();
+  async findAll() {
+    try {
+      return await this.productsService.getProducts();
+    } catch (error) {
+      throw new HttpException(
+        'Failed to fetch products',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    try {
+      return await this.productsService.getProduct(id);
+    } catch (error) {
+      throw new HttpException(
+        'Failed to fetch product',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  @Put(':id')
+  async updateProduct(
+    @Param('id') id: string,
+    @Body()
+    dto: Partial<{
+      name: string;
+      category: string;
+      price: number;
+      location: string;
+    }>,
+  ) {
+    try {
+      return await this.productsService.updateProduct(id, dto);
+    } catch (error) {
+      throw new HttpException(
+        'Failed to update product',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Delete(':id')
+  async deleteProduct(@Param('id') id: string) {
+    try {
+      return await this.productsService.deleteProduct(id);
+    } catch (error) {
+      throw new HttpException(
+        'Failed to delete product',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 }

--- a/services/api-gateway/src/app/products.service.ts
+++ b/services/api-gateway/src/app/products.service.ts
@@ -1,14 +1,81 @@
 import { Injectable } from '@nestjs/common';
-import { Product } from '@my-microservices/shared-types';
+
+interface CreateProductDto {
+  name: string;
+  category: string;
+  price: number;
+  location: string;
+}
 
 @Injectable()
 export class ProductsService {
-  private readonly products: Product[] = [
-    { id: '1', name: 'Organic Rice', category: 'grain', price: 500, location: 'Bangkok' },
-    { id: '2', name: 'Dried Mango', category: 'fruit', price: 120, location: 'Chiang Mai' }
-  ];
+  private readonly productServiceUrl =
+    process.env.API_PRODUCTS_URL ||
+    (process.env.NODE_ENV === 'production'
+      ? 'http://api-products:3002'
+      : 'http://localhost:3002');
 
-  findAll(): Product[] {
-    return this.products;
+  async createProduct(dto: CreateProductDto) {
+    const response = await fetch(`${this.productServiceUrl}/api/products`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(dto),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to create product: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getProducts() {
+    const response = await fetch(`${this.productServiceUrl}/api/products`);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch products: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getProduct(id: string) {
+    const response = await fetch(`${this.productServiceUrl}/api/products/${id}`);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch product: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async updateProduct(id: string, dto: Partial<CreateProductDto>) {
+    const response = await fetch(`${this.productServiceUrl}/api/products/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(dto),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update product: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async deleteProduct(id: string) {
+    const response = await fetch(`${this.productServiceUrl}/api/products/${id}`, {
+      method: 'DELETE',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete product: ${response.statusText}`);
+    }
+
+    return response.json();
   }
 }

--- a/services/api-products/eslint.config.mjs
+++ b/services/api-products/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [...baseConfig];

--- a/services/api-products/jest.config.ts
+++ b/services/api-products/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'api-products',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/api-products',
+};

--- a/services/api-products/project.json
+++ b/services/api-products/project.json
@@ -1,0 +1,44 @@
+{
+  "name": "api-products",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "services/api-products/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "webpack-cli build",
+        "args": ["--node-env=production"]
+      },
+      "configurations": {
+        "development": {
+          "args": ["--node-env=development"]
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "development",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "api-products:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "api-products:build:development"
+        },
+        "production": {
+          "buildTarget": "api-products:build:production"
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/services/api-products/src/app/app.controller.spec.ts
+++ b/services/api-products/src/app/app.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {
+  let app: TestingModule;
+  let controller: AppController;
+
+  beforeEach(async () => {
+    app = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+    controller = app.get<AppController>(AppController);
+  });
+
+  it('should return "Hello API"', () => {
+    expect(controller.getData()).toEqual({ message: 'Hello API' });
+  });
+
+  it('should create, retrieve, update and delete a product', () => {
+    expect(controller.getProducts()).toHaveLength(2);
+    const created = controller.createProduct({
+      name: 'Coffee Beans',
+      category: 'beverage',
+      price: 250,
+      location: 'Chiang Rai',
+    });
+    expect(created).toEqual({
+      id: '3',
+      name: 'Coffee Beans',
+      category: 'beverage',
+      price: 250,
+      location: 'Chiang Rai',
+    });
+    expect(controller.getProduct('3')).toEqual(created);
+    const updated = controller.updateProduct('3', { price: 260 });
+    expect(updated).toEqual({
+      id: '3',
+      name: 'Coffee Beans',
+      category: 'beverage',
+      price: 260,
+      location: 'Chiang Rai',
+    });
+    const removed = controller.deleteProduct('3');
+    expect(removed).toEqual(updated);
+    expect(controller.getProduct('3')).toBeUndefined();
+  });
+});

--- a/services/api-products/src/app/app.controller.ts
+++ b/services/api-products/src/app/app.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { AppService } from './app.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getData() {
+    return this.appService.getData();
+  }
+
+  @Post('products')
+  createProduct(@Body() dto: CreateProductDto) {
+    return this.appService.createProduct(dto);
+  }
+
+  @Get('products')
+  getProducts() {
+    return this.appService.getProducts();
+  }
+
+  @Get('products/:id')
+  getProduct(@Param('id') id: string) {
+    return this.appService.getProduct(id);
+  }
+
+  @Put('products/:id')
+  updateProduct(
+    @Param('id') id: string,
+    @Body() dto: UpdateProductDto,
+  ) {
+    return this.appService.updateProduct(id, dto);
+  }
+
+  @Delete('products/:id')
+  deleteProduct(@Param('id') id: string) {
+    return this.appService.deleteProduct(id);
+  }
+}

--- a/services/api-products/src/app/app.module.ts
+++ b/services/api-products/src/app/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { HealthModule } from '@my-microservices/shared-utils';
+
+@Module({
+  imports: [HealthModule.register('api-products')],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/services/api-products/src/app/app.service.spec.ts
+++ b/services/api-products/src/app/app.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test } from '@nestjs/testing';
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  let service: AppService;
+
+  beforeEach(async () => {
+    const app = await Test.createTestingModule({
+      providers: [AppService],
+    }).compile();
+
+    service = app.get<AppService>(AppService);
+  });
+
+  it('should return "Hello API"', () => {
+    expect(service.getData()).toEqual({ message: 'Hello API' });
+  });
+
+  it('should create, retrieve, update and delete a product', () => {
+    expect(service.getProducts()).toHaveLength(2);
+    const created = service.createProduct({
+      name: 'Coffee Beans',
+      category: 'beverage',
+      price: 250,
+      location: 'Chiang Rai',
+    });
+    expect(created).toEqual({
+      id: '3',
+      name: 'Coffee Beans',
+      category: 'beverage',
+      price: 250,
+      location: 'Chiang Rai',
+    });
+    expect(service.getProduct('3')).toEqual(created);
+    const updated = service.updateProduct('3', { price: 260 });
+    expect(updated).toEqual({
+      id: '3',
+      name: 'Coffee Beans',
+      category: 'beverage',
+      price: 260,
+      location: 'Chiang Rai',
+    });
+    const removed = service.deleteProduct('3');
+    expect(removed).toEqual(updated);
+    expect(service.getProduct('3')).toBeUndefined();
+  });
+});

--- a/services/api-products/src/app/app.service.ts
+++ b/services/api-products/src/app/app.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { Product } from '@my-microservices/shared-types';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+
+@Injectable()
+export class AppService {
+  private products: Product[] = [
+    { id: '1', name: 'Organic Rice', category: 'grain', price: 500, location: 'Bangkok' },
+    { id: '2', name: 'Dried Mango', category: 'fruit', price: 120, location: 'Chiang Mai' },
+  ];
+  private nextId = 3;
+
+  getData(): { message: string } {
+    return { message: 'Hello API' };
+  }
+
+  getProducts(): Product[] {
+    return this.products;
+  }
+
+  getProduct(id: string): Product | undefined {
+    return this.products.find((p) => p.id === id);
+  }
+
+  createProduct(dto: CreateProductDto): Product {
+    const product: Product = { id: `${this.nextId++}`, ...dto };
+    this.products.push(product);
+    return product;
+  }
+
+  updateProduct(id: string, dto: UpdateProductDto): Product | undefined {
+    const product = this.getProduct(id);
+    if (product) {
+      Object.assign(product, dto);
+    }
+    return product;
+  }
+
+  deleteProduct(id: string): Product | undefined {
+    const index = this.products.findIndex((p) => p.id === id);
+    if (index >= 0) {
+      const [removed] = this.products.splice(index, 1);
+      return removed;
+    }
+    return undefined;
+  }
+}

--- a/services/api-products/src/app/dto/create-product.dto.ts
+++ b/services/api-products/src/app/dto/create-product.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class CreateProductDto {
+  @IsNotEmpty()
+  @IsString()
+  name!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  category!: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  price!: number;
+
+  @IsNotEmpty()
+  @IsString()
+  location!: string;
+}

--- a/services/api-products/src/app/dto/update-product.dto.ts
+++ b/services/api-products/src/app/dto/update-product.dto.ts
@@ -1,0 +1,19 @@
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class UpdateProductDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @IsOptional()
+  @IsNumber()
+  price?: number;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
+}

--- a/services/api-products/src/main.ts
+++ b/services/api-products/src/main.ts
@@ -1,0 +1,21 @@
+/**
+ * This is not a production server yet!
+ * This is only a minimal backend to get started.
+ */
+
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app/app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const globalPrefix = 'api';
+  app.setGlobalPrefix(globalPrefix);
+  const port = process.env.PORT || 3002;
+  await app.listen(port);
+  Logger.log(
+    `🚀 Application is running on: http://localhost:${port}/${globalPrefix}`
+  );
+}
+
+bootstrap();

--- a/services/api-products/tsconfig.app.json
+++ b/services/api-products/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "target": "es2021"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/services/api-products/tsconfig.json
+++ b/services/api-products/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/services/api-products/tsconfig.spec.json
+++ b/services/api-products/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/services/api-products/webpack.config.js
+++ b/services/api-products/webpack.config.js
@@ -1,0 +1,20 @@
+const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '../../dist/api-products'),
+  },
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      assets: ['./src/assets'],
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: true,
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary
- add standalone api-products service with CRUD operations
- route product requests through gateway to new service
- update docker, build scripts, and env for api-products

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4e1cf9a0832caa3783628624cdf6